### PR TITLE
Fedora GNU/Linux as the base image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## :information_source: Fork Notes
+
+Very, very minor tweaks to run in Fedora GNU/Linux instead of Ubuntu GNU/Linux because I like my familar base.
+
+**WARNING:** Fedora is not officially supported by the Golem Network.
+
 #  Golem Provider Node :whale: Docker Image
 
 > Project won one of the four prizes allocated by the Golem Project on Gitcoin's [Hack New Golem](https://gitcoin.co/issue/golemfactory/hackathons/6/100024411) bounty!

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-ARG UBUNTU_VERSION=20.04
+ARG FEDORA_BASE=fedora
+ARG FEDORA_VERSION=34
 ARG YA_CORE_VERSION=0.9.2
 ARG YA_WASI_VERSION=0.2.2
 ARG YA_VM_VERSION=0.2.10
@@ -6,17 +7,16 @@ ARG YA_DIR_BIN=/usr/bin/
 ARG YA_DIR_BIN_TMP=/golem-provider-bin/
 ARG YA_DIR_PLUGINS=/lib/yagna/plugins/
 
-FROM ubuntu:${UBUNTU_VERSION} as installer
+FROM ${FEDORA_BASE}:${FEDORA_VERSION} as installer
 ARG YA_CORE_VERSION
 ARG YA_WASI_VERSION
 ARG YA_VM_VERSION
 ARG YA_DIR_BIN_TMP
 ARG YA_DIR_PLUGINS
-RUN apt-get update -q \
-&& apt-get install -q -y --no-install-recommends \
+RUN dnf install -y \
     wget \
     ca-certificates \
-    xz-utils \
+    xz \
 && mkdir -p ${YA_DIR_BIN_TMP} \
 && mkdir -p ${YA_DIR_PLUGINS} \
 && wget -q "https://github.com/golemfactory/yagna/releases/download/v${YA_CORE_VERSION}/golem-provider-linux-v${YA_CORE_VERSION}.tar.gz" \
@@ -30,14 +30,13 @@ RUN apt-get update -q \
 && cp -R ya-runtime-wasi-linux-v${YA_WASI_VERSION}/* ${YA_DIR_PLUGINS} \
 && cp -R ya-runtime-vm-linux-v${YA_VM_VERSION}/* ${YA_DIR_PLUGINS}
 
-FROM ubuntu:${UBUNTU_VERSION}
+FROM ${FEDORA_BASE}:${FEDORA_VERSION}
 ARG YA_DIR_BIN
 ARG YA_DIR_BIN_TMP
 ARG YA_DIR_PLUGINS
-RUN apt-get update -q \
-&& apt-get install -q -y --no-install-recommends ca-certificates \
-&& apt-get clean -y \
-&& rm -rf /var/lib/apt/lists/*
+RUN dnf install -y ca-certificates \
+&& dnf clean all \
+&& rm -Rf /var/cache/dnf
 COPY --from=installer ${YA_DIR_PLUGINS} ${YA_DIR_PLUGINS}
 COPY --from=installer ${YA_DIR_BIN_TMP} ${YA_DIR_BIN}
 


### PR DESCRIPTION
Switches from Ubuntu and apt-get to Fedora and dnf.
Allows for different Fedora bases, like `registry.fedoraproject.org/fedora-minimal:34`.